### PR TITLE
Install ttf-mscorefonts-installer

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Install LibreOffice
         run: sudo apt-get update && sudo apt-get install libreoffice --no-install-recommends
 
+      - name: Install ttf-mscorefonts-installer
+        run: |
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get update && sudo apt-get install ttf-mscorefonts-installer
+          sudo fc-cache -f
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 


### PR DESCRIPTION
This PR installs `ttf-mscorefonts-installer` in the GitHub Actions workflow, so that LibreOffice can find the appropriate fonts when rendering the RTF into PDF.