### PR TITLE
Remove pip-compile command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ uv sync
 Update dependencies:
 
 ```bash
-uv sync
 uv lock --upgrade
-source .venv/bin/activate
-pip-compile --generate-hashes
+uv sync
 ```
-
-`pip-compile` is part of pip-tools and is used to generate the
-`requirements.txt` file used by the Quarto GitHub Actions workflow.


### PR DESCRIPTION
This PR removes the `pip-compile` command from `README.md` since `requirements.txt` is no longer needed by the GitHub Actions workflow (all using uv now).