### PR TITLE
Add devcontainer deps for PDF functionalities

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "uv sync",
+	"postCreateCommand": "uv sync && sudo apt-get update -y -qq && sudo apt-get install -y libreoffice texlive texlive-luatex texlive-latex-extra texlive-fonts-extra",
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -25,6 +25,7 @@
 				"tamasfe.even-better-toml",
 				"ms-toolsai.jupyter",
 				"quarto.quarto",
+				"James-Yu.latex-workshop",
 				"nanxstats.textmate-rstheme"
 			],
 			"settings": {


### PR DESCRIPTION
This PR adds these dependencies to the devcontainer, to support PDF related functionalities:

- LibreOffice for converting RTF to PDF, used by rtflite
- `texlive`, `texlive-luatex`, `texlive-latex-extra`, `texlive-fonts-extra` to render the Quarto book to PDF
- VS Code extension [Latex Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) (4M+ downloads, MIT license) for previewing PDF files

Now you can run `quarto render` to build the entire book from source within the browser using GitHub Codespaces.