### PR TITLE
Correct link for PharmaDS 2026 slides

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -26,6 +26,6 @@ regulatory submission and effective team collaboration.
 |-------|------|------|-----------|
 | R/Pharma Conference | Workshop | 2025-11-07 | [Slides](https://pycsr.org/slides/rinpharma2025/), [video](https://www.youtube.com/watch?v=e-ZjrLA_ev8) |
 | PharmaDS 2026 Conference | Short course | 2026-03-23 | [Slides: Part I](https://pycsr.org/slides/pharmads2026/part1/) |
-| PharmaDS 2026 Conference | Short course | 2026-03-23 | [Slides: Part III](https://github.com/user-attachments/files/26182994/demo_tutorial.pdf/) |
+| PharmaDS 2026 Conference | Short course | 2026-03-23 | [Slides: Part III](https://github.com/user-attachments/files/26182994/demo_tutorial.pdf) |
 
 :::


### PR DESCRIPTION
Removing the additional `/` after the `.pdf` file extension (somehow it works, although not canonical).