### PR TITLE
Enable code echoing in RTF document examples

### DIFF
--- a/tlf-overview.qmd
+++ b/tlf-overview.qmd
@@ -320,7 +320,7 @@ A minimal example below illustrates how to combine components to create an RTF t
 - `write_rtf()` saves encoded RTF into a `.rtf` file.
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create simple RTF document
 doc = rtf.RTFDocument(
     df=tbl.head(6),
@@ -351,7 +351,7 @@ Only the ratio of `col_rel_width` is used.
 Therefore it is equivalent to use `col_rel_width = [6,4,4,4]` or `col_rel_width = [1.5,1,1,1]`.
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create RTF document with custom column widths
 doc = rtf.RTFDocument(
     df=tbl.head(6),
@@ -376,7 +376,7 @@ In `RTFColumnHeader`, the `text` argument provides the column header content
 as a list of strings.
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create RTF document with column headers
 doc = rtf.RTFDocument(
     df=tbl.head(6),
@@ -412,7 +412,7 @@ By using `RTFColumnHeader` with `col_rel_width`, one can customize complex colum
 If there are multiple pages, the column header will repeat on each page by default.
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create RTF document with multi-line column headers
 doc = rtf.RTFDocument(
     df=tbl.head(50),
@@ -451,7 +451,7 @@ RTF documents can include additional components to provide context and documenta
 - `RTFSource`: Add data source attribution
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create RTF document with titles, footnotes, and source
 doc = rtf.RTFDocument(
     df=tbl.head(15),
@@ -497,7 +497,7 @@ rtflite supports various text formatting options:
 - **Font properties**: Font size, font family
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create RTF document with text formatting and alignment
 doc = rtf.RTFDocument(
     df=tbl.head(10),
@@ -536,7 +536,7 @@ Table borders can be customized extensively:
 - **Page borders**: `border_first`, `border_last` for first/last rows across pages
 
 ```{python}
-#| echo: false
+#| echo: true
 # Create RTF document with custom borders
 doc = rtf.RTFDocument(
     df=tbl.head(8),


### PR DESCRIPTION
`echo: true` to show rtflite code snippets.

The HTML is showing this currently-
<img width="656" height="314" alt="image" src="https://github.com/user-attachments/assets/efdc019a-353d-4da2-8b7e-4f04297fa880" />
